### PR TITLE
Remove redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,6 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: bullettrain
     container_name: bullettrain_postgres
-  redis:
-    image: redis:alpine
-    ports:
-      - "6379:6379"
-    container_name: bullettrain_redis
   api:
     image: bullettrain/api:latest
     environment:
@@ -21,15 +16,12 @@ services:
       DJANGO_DB_USER: postgres
       DJANGO_DB_PASSWORD: password
       DJANGO_DB_PORT: 5432
-      REDIS_URL: redis://redis:6379/
     ports:
       - "8000:8000"
     depends_on:
       - db
-      - redis
     links:
       - db:db
-      - redis:redis
     container_name: bullettrain_api
   frontend:
     image: bullettrain/frontend:latest


### PR DESCRIPTION
If redis isn't used, removing it here helps understand the barrier to setup much better. I thought I had to setup a redis cluster to support Bullet Train, but it looks like that isn't the case (I can't see any reference to redis in the code other than in this file, but I may be missing something.