### PR TITLE
Add environment variable to ensure that recurring tasks are registered

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,6 @@ services:
     image: flagsmith/flagsmith:latest
     environment:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
-      LOG_LEVEL: DEBUG
       USE_POSTGRES_FOR_ANALYTICS: "True"
     entrypoint:
       - "python"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     image: flagsmith/flagsmith:latest
     environment:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
+      LOG_LEVEL: DEBUG
+      USE_POSTGRES_FOR_ANALYTICS: "True"
     entrypoint:
       - "python"
       - "manage.py"


### PR DESCRIPTION
The task processor also needs the postgres analytics environment variable set to make sure it registers the downsampling task. 