### PR TITLE
chore: add dummy secret key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       DJANGO_ALLOWED_HOSTS: "*" # Change this in production
       ALLOW_ADMIN_INITIATION_VIA_CLI: "true" # Change this in production
       FLAGSMITH_DOMAIN: "localhost:8000" # Change this in production
+      DJANGO_SECRET_KEY: "secret" # Change this in production
       # PREVENT_SIGNUP: "true" # Uncomment to prevent additional signups
       # ENABLE_ADMIN_ACCESS_USER_PASS: "true" # set to "true" to enable access to the /admin/ Django backend via your username and password
       # ALLOW_REGISTRATION_WITHOUT_INVITE: "true"


### PR DESCRIPTION
Fixes issues with using the CLI generated password reset URL once the server starts up. 